### PR TITLE
Update PayPal link to use giving fund, clarify fees around Facebook donations

### DIFF
--- a/index.html
+++ b/index.html
@@ -363,7 +363,7 @@
                   <div>Donate with Debit / Credit Card</div>
                 </a>
               </div>
-              <div class="text-block-20">PayPal giving fund donations have no fees.</div>
+              <div class="text-block-20">PayPal giving fund donations have no fees, which means 100% of the amount goes to the church.</div>
               <div class="text-block-8"><span class="text-span-8"></span> Facebook</div>
               <div class="text-block-20">Your Facebook donations are secure and easy, but they charge processing fees to the church. Navigate to the church page and click the &quot;Donate&quot; button.</div>
               <div class="card--light donate--card">

--- a/index.html
+++ b/index.html
@@ -359,12 +359,13 @@
             <div>
               <div class="text-block-8"><span class="text-span-7"></span> Paypal</div>
               <div class="card--light donate--card">
-                <a href="https://www.paypal.com/donate/?hosted_button_id=TDVCGBF8TGMBL" target="_blank" class="button donate--button w-inline-block">
+                <a href="https://paypal.com/us/fundraiser/charity/2031438" target="_blank" class="button donate--button w-inline-block">
                   <div>Donate with Debit / Credit Card</div>
                 </a>
               </div>
+              <div class="text-block-20">PayPal giving fund donations have no fees.</div>
               <div class="text-block-8"><span class="text-span-8"></span> Facebook</div>
-              <div class="text-block-20">Your Facebook donations are 100% secure, with no fees. Navigate to the church page and click the &quot;Donate&quot; button.</div>
+              <div class="text-block-20">Your Facebook donations are secure and easy, but they charge processing fees to the church. Navigate to the church page and click the &quot;Donate&quot; button.</div>
               <div class="card--light donate--card">
                 <a href="https://www.facebook.com/StGeorgeCopticSeattle/" target="_blank" class="button donate--button w-inline-block">
                   <div>Donate with Facebook</div>


### PR DESCRIPTION
Marc integrated with PayPal's giving fund which charges no fees. This change updates the PayPal link to use the giving fund instead of the generic donation which does charge fees.