### PR TITLE
Update homepage liturgy and services schedule from public calendar

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,11 +4,11 @@
 <head>
   <meta charset="utf-8">
   <title>St. George Coptic Orthodox Church | Kirkland, WA - Greater Seattle Area</title>
-  <meta content="A Coptic Orthodox Church located in Kirkland, WA with services for the Greater Seattle Area. Liturgies prayer every Wednesday and Sunday. Check our website and social media for more information." name="description">
+  <meta content="A Coptic Orthodox Church located in Kirkland, WA with services for the Greater Seattle Area. Divine Liturgies are currently scheduled on Sundays, Saturdays, and Wednesdays (Arabic), with additional meetings and ministries throughout the week." name="description">
   <meta content="St. George Coptic Orthodox Church | Kirkland, WA - Greater Seattle Area" property="og:title">
-  <meta content="A Coptic Orthodox Church located in Kirkland, WA with services for the Greater Seattle Area. Liturgies prayer every Wednesday and Sunday. Check our website and social media for more information." property="og:description">
+  <meta content="A Coptic Orthodox Church located in Kirkland, WA with services for the Greater Seattle Area. Divine Liturgies are currently scheduled on Sundays, Saturdays, and Wednesdays (Arabic), with additional meetings and ministries throughout the week." property="og:description">
   <meta content="St. George Coptic Orthodox Church | Kirkland, WA - Greater Seattle Area" property="twitter:title">
-  <meta content="A Coptic Orthodox Church located in Kirkland, WA with services for the Greater Seattle Area. Liturgies prayer every Wednesday and Sunday. Check our website and social media for more information." property="twitter:description">
+  <meta content="A Coptic Orthodox Church located in Kirkland, WA with services for the Greater Seattle Area. Divine Liturgies are currently scheduled on Sundays, Saturdays, and Wednesdays (Arabic), with additional meetings and ministries throughout the week." property="twitter:description">
   <meta property="og:type" content="website">
   <meta content="summary_large_image" name="twitter:card">
   <meta content="width=device-width, initial-scale=1" name="viewport">
@@ -97,7 +97,7 @@
       <div class="section_row">
         <div class="section_col align--middle"><img src="images/st_george_logo.jpeg" loading="lazy" sizes="(max-width: 479px) 100px, 150px" srcset="images/st_george_logo-p-500.jpeg 500w, images/st_george_logo-p-800.jpeg 800w, images/st_george_logo-p-1080.jpeg 1080w, images/st_george_logo.jpeg 1248w" alt="" class="image">
           <h1 class="heading">St. George Coptic Orthodox Church</h1>
-          <p class="paragraph-2">A Coptic Orthodox Church with services for the Greater Seattle Area</p>
+          <p class="paragraph-2">A Coptic Orthodox Church with liturgies, services, and ministries for the Greater Seattle Area</p>
           <div class="footer_social">
             <a href="https://www.facebook.com/StGeorgeCopticSeattle/" target="_blank" class="social_link w-inline-block">
               <div class="social_link_icon"></div>
@@ -294,9 +294,9 @@
         <div class="section_col">
           <div class="card--light">
             <div class="text--feature">Vespers &amp; Midnight Praises</div>
-            <p class="paragraph-10 more-services-paragraph"><span class="text-span-6">Saturdays:</span> 7:00 PM to 8:00 PM<a href="tel:+14252025570" target="_blank"></a><br></p>
+            <p class="paragraph-10 more-services-paragraph"><span class="text-span-6">Saturdays:</span> 7:00 PM to 8:30 PM<a href="tel:+14252025570" target="_blank"></a><br></p>
             <div class="text--feature">Divine Liturgies</div>
-            <p class="paragraph-13"><span class="text-span-3">Wednesdays:</span> 8:30 AM - 10:30 AM<br><span class="text-span-5">Sundays:</span> 8:30 AM - 11:00 AM<a href="http://www.stmaryseattle.org/Default.aspx"><br></a>
+            <p class="paragraph-13"><span class="text-span-3">Saturdays:</span> 9:00 AM - 11:00 AM<br><span class="text-span-3">Sundays:</span> 8:15 AM - 11:00 AM<br><span class="text-span-5">Wednesdays (Arabic):</span> 9:00 AM - 11:00 AM<a href="http://www.stmaryseattle.org/Default.aspx"><br></a>
             </p>
           </div>
           <div class="card--light">
@@ -317,18 +317,16 @@
           </div>
           <div class="card--light">
             <div class="text--feature">More services ...</div>
-            <h3 class="text--large">English bible study</h3>
-            <p class="paragraph-10 more-services-paragraph">Wednesdays from 7:30 PM to 8:30 PM<a href="tel:+14252025570" target="_blank"></a><br></p>
             <h3 class="text--large">Arabic bible study</h3>
-            <p class="paragraph-10 more-services-paragraph">Wednesdays from 7:00 PM to 8:00 PM<br></p>
-            <h3 class="text--large">Sisters in Christ meeting</h3>
-            <p class="paragraph-10 more-services-paragraph">Every other Thursday from 7:30 PM to 8:30 PM. For more information join the <a href="https://www.facebook.com/groups/419517219013675/" target="_blank">Sisters in Christ Facebook group</a>
-              <a href="tel:+14252025570" target="_blank"></a><br>
-            </p>
-            <h3 class="text--large">Scouts</h3>
-            <p class="paragraph-10 more-services-paragraph">During the summer of 2021, we are gathering every other Saturday. For more information join the <a href="https://facebook.com/groups/1105022559644467" target="_blank">Scouts Facebook group</a><br></p>
+            <p class="paragraph-10 more-services-paragraph">Saturdays from 11:45 AM to 12:30 PM<br></p>
+            <h3 class="text--large">English general meeting</h3>
+            <p class="paragraph-10 more-services-paragraph">Sundays from 11:45 AM to 12:30 PM<br></p>
+            <h3 class="text--large">Arabic general meeting</h3>
+            <p class="paragraph-10 more-services-paragraph">Sundays from 11:45 AM to 12:30 PM<br></p>
+            <h3 class="text--large">Scouts &amp; community groups</h3>
+            <p class="paragraph-10 more-services-paragraph">Additional gatherings are scheduled throughout the year. Please check the public calendar and follow our service channels for the latest updates.<br></p>
             <h3 class="text--large">Coptic bookstore</h3>
-            <p class="paragraph-10 more-services-paragraph">For more information join the the <a href="https://www.facebook.com/groups/318559502821833/?ref=share" target="_blank">Bookstore Facebook group</a><br></p>
+            <p class="paragraph-10 more-services-paragraph">For more information join the <a href="https://www.facebook.com/groups/318559502821833/?ref=share" target="_blank">Bookstore Facebook group</a><br></p>
             <div class="separator services-separator"></div>
             <h3 class="text--large">Hymn lessons</h3>
             <h3 class="text--large">Choir</h3>


### PR DESCRIPTION
### Motivation
- Ensure the homepage content matches the church’s public calendar feed and presents an accurate, up-to-date liturgy and services schedule.
- Remove outdated seasonal/2021 references and make recurring service times clear so visitors can rely on the page without needing to inspect the calendar file directly.

### Description
- Updated the page metadata (`description`, `og:description`, `twitter:description`) to reflect current liturgy cadence and week-long ministries. 
- Updated the visible hero description to mention liturgies, services, and ministries instead of the older generic wording. 
- Reworked the Services section in `index.html` to update times and labels, including Saturday Vespers (now `7:00 PM - 8:30 PM`), Saturday Divine Liturgy (`9:00 AM - 11:00 AM`), Sunday Divine Liturgy (`8:15 AM - 11:00 AM`), and Wednesday Arabic Divine Liturgy (`9:00 AM - 11:00 AM`), and replaced several outdated items under “More services” with current recurring entries and a calendar-first note. 
- Saved the updated `index.html` with the refreshed copy and schedule values that were derived from the public ICS feed.

### Testing
- Fetched the public calendar with `curl -L .../public/basic.ics` and verified the feed downloaded successfully (file written to `/tmp/calendar.ics`).
- Parsed and inspected the ICS file using Python scripts to enumerate recurring `VEVENT` entries and confirm active liturgy/service recurrences used for the content update, and the parser output matched expected recurring summaries (e.g., `Divine Liturgy`, `Vespers & Tasbeha`).
- Ran `git diff --check` on the updated tree and found no whitespace/diff issues.
- All automated checks executed in the rollout completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3b88d1cc48323961d3d36a29690c7)