### PR TITLE
Remove old number for St Abraham service

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,7 +313,7 @@
           <div class="card--light">
             <div class="text--feature">Saint Abraham</div>
             <h3 class="text--large">Newcomers</h3>
-            <p class="paragraph-10">Saint Abraham service is for newcomers and immigrants families and individuals relocating to the Seattle area. The service goal is to show Christ&#x27;s love to people starting a new life in Seattle. We provide relocation support as needed, including advice on housing, schools, support in filing for employment applications and a driver&#x27;s license. <br><br>Unfortunately we do not have any employment opportunities at Church or temporary housing.<br><br><strong>هل تحتاج لمساعدة في الاستقرار فى الولاية؟‎<br></strong>Email: <a href="mailto:stabraham@stgeorgeseattle.org">stabraham@stgeorgeseattle.org</a><br>Call or text: <a href="tel:+14252025570" target="_blank">+1 (425) 202 5570</a><br></p>
+            <p class="paragraph-10">Saint Abraham service is for newcomers and immigrants families and individuals relocating to the Seattle area. The service goal is to show Christ&#x27;s love to people starting a new life in Seattle. We provide relocation support as needed, including advice on housing, schools, support in filing for employment applications and a driver&#x27;s license. <br><br>Unfortunately we do not have any employment opportunities at Church or temporary housing.<br><br><strong>هل تحتاج لمساعدة في الاستقرار فى الولاية؟‎<br></strong>Email: <a href="mailto:stabraham@stgeorgeseattle.org">stabraham@stgeorgeseattle.org</a></p>
           </div>
           <div class="card--light">
             <div class="text--feature">More services ...</div>


### PR DESCRIPTION
## Problem

The Saint Abraham service card on the homepage still displayed an old phone number.

## Change

- Removed the `Call or text` phone number and `tel:` link from the Saint Abraham service card.
- Preserved the Saint Abraham email address.
- Left the church's separate general-contact phone numbers unchanged.

## Verification

- `git diff --check` passed.
- Served the homepage locally and verified the Saint Abraham card contains one email link and no telephone links.
- Confirmed the remaining copy and layout render correctly with no browser console errors.
- Compared exact before/after screenshots of the affected homepage section.

This repository has no automated test suite or CI definition; the change is static HTML content only.
